### PR TITLE
Add conversation support to query flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,9 +5,11 @@ import QueryResult from './components/QueryResult';
 import LoadingSpinner from './components/LoadingSpinner';
 import ErrorMessage from './components/ErrorMessage';
 import { queryMedicalInfo } from './services/api';
-import { QueryResponse, QueryStatus } from './types';
+import { QueryResponse, QueryStatus, QueryHistory } from './types';
 
 function App() {
+  const [conversationId] = useState<string>(() => crypto.randomUUID());
+  const [history, setHistory] = useState<QueryHistory[]>([]);
   const [status, setStatus] = useState<QueryStatus>('idle');
   const [result, setResult] = useState<QueryResponse | null>(null);
   const [error, setError] = useState<string>('');
@@ -19,9 +21,10 @@ function App() {
       setResult(null);
 
       console.log('🔍 開始查詢:', query);
-      const response = await queryMedicalInfo(query);
-      
+      const response = await queryMedicalInfo(conversationId, query);
+
       setResult(response);
+      setHistory((prev) => [...prev, { id: crypto.randomUUID(), query: response.query, response: response.response, timestamp: response.timestamp, status: 'success' }]);
       setStatus('success');
       console.log('✅ 查詢完成:', response);
     } catch (err: any) {
@@ -116,4 +119,4 @@ function App() {
   );
 }
 
-export default App; 
+export default App;

--- a/client/src/components/ErrorMessage.tsx
+++ b/client/src/components/ErrorMessage.tsx
@@ -50,4 +50,4 @@ const ErrorMessage: React.FC<ErrorMessageProps> = ({ error, onRetry }) => {
   );
 };
 
-export default ErrorMessage; 
+export default ErrorMessage;

--- a/client/src/components/LoadingSpinner.tsx
+++ b/client/src/components/LoadingSpinner.tsx
@@ -48,4 +48,4 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   );
 };
 
-export default LoadingSpinner; 
+export default LoadingSpinner;

--- a/client/src/components/QueryForm.tsx
+++ b/client/src/components/QueryForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Search, Send, Loader2 } from 'lucide-react';
 
 interface QueryFormProps {
-  onSubmit: (query: string) => void;
+  onSubmit: (message: string) => void;
   isLoading: boolean;
 }
 
@@ -92,5 +92,5 @@ const QueryForm: React.FC<QueryFormProps> = ({ onSubmit, isLoading }) => {
   );
 };
 
-export default QueryForm; 
- 
+export default QueryForm;
+

--- a/client/src/components/QueryResult.tsx
+++ b/client/src/components/QueryResult.tsx
@@ -105,4 +105,4 @@ const QueryResult: React.FC<QueryResultProps> = ({ result }) => {
   );
 };
 
-export default QueryResult; 
+export default QueryResult;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,4 +7,4 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-) 
+);

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -37,9 +37,12 @@ apiClient.interceptors.response.use(
 );
 
 // 醫療資訊查詢 API
-export const queryMedicalInfo = async (query: string): Promise<QueryResponse> => {
+export const queryMedicalInfo = async (
+  conversationId: string,
+  message: string
+): Promise<QueryResponse> => {
   try {
-    const response = await apiClient.post<QueryResponse>('/query', { query });
+    const response = await apiClient.post<QueryResponse>('/query', { conversationId, message });
     return response.data;
   } catch (error: any) {
     if (error.response?.data) {
@@ -59,4 +62,4 @@ export const checkHealth = async (): Promise<{ status: string; timestamp: string
   }
 };
 
-export default apiClient; 
+export default apiClient;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -34,4 +34,4 @@ export interface QueryHistory {
 export interface ErrorResponse {
   error: string;
   message: string;
-} 
+}

--- a/server/routes/query.js
+++ b/server/routes/query.js
@@ -1,39 +1,49 @@
 const express = require('express');
-const { processMedicalQueryReact } = require('../services/reactAgentService');
+const { processMedicalQueryReact, SYSTEM_PROMPT } = require('../services/reactAgentService');
+const conversationService = require('../services/conversationService');
 
 const router = express.Router();
 
 // 醫療資訊查詢端點
 router.post('/', async (req, res) => {
   try {
-    const { query } = req.body;
+    const { conversationId, message } = req.body;
 
     // 驗證輸入
-    if (!query || typeof query !== 'string' || query.trim().length === 0) {
+    if (!message || typeof message !== 'string' || message.trim().length === 0) {
       return res.status(400).json({
         error: '查詢內容不能為空',
         message: '請提供有效的查詢內容'
       });
     }
 
-    if (query.length > 500) {
+    if (message.length > 500) {
       return res.status(400).json({
         error: '查詢內容過長',
         message: '查詢內容不能超過 500 個字元'
       });
     }
 
-    console.log(`🔍 收到查詢: ${query}`);
+    console.log(`🔍 收到查詢: ${message}`);
 
-    // 處理查詢
-    const result = await processMedicalQueryReact(query.trim());
+    let messages = conversationService.getMessages(conversationId);
+    if (messages.length === 0) {
+      messages.push({ role: 'system', content: SYSTEM_PROMPT });
+    }
+    messages.push({ role: 'user', content: message.trim() });
+
+    const result = await processMedicalQueryReact(messages);
+
+    messages.push({ role: 'assistant', content: result.response });
+    conversationService.saveMessages(conversationId, messages);
 
     res.json({
       success: true,
-      query: query.trim(),
+      query: message.trim(),
       response: result.response,
       searchResults: result.searchResults,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      conversationId
     });
 
   } catch (error) {
@@ -70,4 +80,4 @@ router.get('/history', (req, res) => {
   });
 });
 
-module.exports = router; 
+module.exports = router;

--- a/server/services/conversationService.js
+++ b/server/services/conversationService.js
@@ -1,0 +1,20 @@
+// 簡易的對話訊息儲存服務，使用記憶體 Map 以 conversationId 為鍵保存訊息陣列
+class ConversationService {
+  constructor() {
+    this.conversations = new Map();
+  }
+
+  // 取得指定 conversationId 的訊息陣列，若不存在則回傳空陣列
+  getMessages(conversationId) {
+    if (!conversationId) return [];
+    return this.conversations.get(conversationId) || [];
+  }
+
+  // 儲存指定 conversationId 的訊息陣列
+  saveMessages(conversationId, messages) {
+    if (!conversationId) return;
+    this.conversations.set(conversationId, messages);
+  }
+}
+
+module.exports = new ConversationService();

--- a/server/services/reactAgentService.js
+++ b/server/services/reactAgentService.js
@@ -29,6 +29,13 @@ class SerperSearchService {
   }
 }
 
+const SYSTEM_PROMPT = `你是一個醫療 ReAct agent，可使用以下工具：\n` +
+  `1. doctor_rag：查詢醫師資料庫\n` +
+  `2. vector_rag：向量檢索醫師資料\n` +
+  `3. web_search：Google 搜尋\n` +
+  `4. finish：輸出最終診斷報告。\n` +
+  `請依序輸出 Thought、Action、Action Input，獲得 Observation 後再繼續，直到使用 finish。回覆語言為繁體中文。`;
+
 // ReAct Agent 服務
 class ReactAgentService {
   constructor() {
@@ -50,18 +57,10 @@ class ReactAgentService {
     return optimizedQuery;
   }
 
-  async run(query) {
-    const systemPrompt = `你是一個醫療 ReAct agent，可使用以下工具：\n` +
-      `1. doctor_rag：查詢醫師資料庫\n` +
-      `2. vector_rag：向量檢索醫師資料\n` +
-      `3. web_search：Google 搜尋\n` +
-      `4. finish：輸出最終診斷報告。\n` +
-      `請依序輸出 Thought、Action、Action Input，獲得 Observation 後再繼續，直到使用 finish。回覆語言為繁體中文。`;
-
-    const messages = [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: query }
-    ];
+  async run(messages) {
+    // 從現有訊息中取得最新的使用者問題
+    const userMessages = messages.filter(m => m.role === 'user' && !m.content.startsWith('Observation'));
+    const latestQuery = userMessages.length > 0 ? userMessages[userMessages.length - 1].content : '';
 
     for (let i = 0; i < 8; i++) {
       const completion = await this.openai.chat.completions.create({
@@ -91,13 +90,13 @@ class ReactAgentService {
 
       let observation = '';
       if (action === 'doctor_rag') {
-        const result = await this.doctorRag.searchDoctors(actionInput || query);
+        const result = await this.doctorRag.searchDoctors(actionInput || latestQuery);
         observation = JSON.stringify(result);
       } else if (action === 'vector_rag') {
-        const result = await this.vectorRag.searchDoctors(actionInput || query);
+        const result = await this.vectorRag.searchDoctors(actionInput || latestQuery);
         observation = JSON.stringify(result);
       } else if (action === 'web_search') {
-        const result = await this.searchService.search(this.optimizeSearchQuery(actionInput || query));
+        const result = await this.searchService.search(this.optimizeSearchQuery(actionInput || latestQuery));
         observation = JSON.stringify(result.organic ? result.organic.slice(0,3) : []);
       } else {
         observation = '未知行動';
@@ -110,10 +109,10 @@ class ReactAgentService {
   }
 }
 
-async function processMedicalQueryReact(query) {
+async function processMedicalQueryReact(messages) {
   const agent = new ReactAgentService();
-  const response = await agent.run(query);
+  const response = await agent.run(messages);
   return { response };
 }
 
-module.exports = { ReactAgentService, processMedicalQueryReact };
+module.exports = { ReactAgentService, processMedicalQueryReact, SYSTEM_PROMPT };

--- a/server/services/reactAgentService.js
+++ b/server/services/reactAgentService.js
@@ -34,7 +34,9 @@ const SYSTEM_PROMPT = `你是一個醫療 ReAct agent，可使用以下工具：
   `2. vector_rag：向量檢索醫師資料\n` +
   `3. web_search：Google 搜尋\n` +
   `4. finish：輸出最終診斷報告。\n` +
-  `請依序輸出 Thought、Action、Action Input，獲得 Observation 後再繼續，直到使用 finish。回覆語言為繁體中文。`;
+  `請依序輸出 Thought、Action、Action Input，獲得 Observation 後再繼續，直到使用 finish。回覆語言為繁體中文。\n` +
+  `當你已經有明確答案時，請務必使用 finish action 結束，不要重複回覆。\n` +
+  `在輸出 finish action 時，請直接給出最終答案，不要加上「抱歉」、「我將正確地完成這次對話」等多餘語句或開場白，只需輸出醫療資訊本身。`;
 
 // ReAct Agent 服務
 class ReactAgentService {


### PR DESCRIPTION
## Summary
- store chat history by conversation id
- support conversation messages in React agent service
- update query route to accept `conversationId` and `message`
- keep conversation state on the client and send along with requests

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6862e6be77c4832597a9afeb00210324